### PR TITLE
Remove fbjs dependency

### DIFF
--- a/example/js/CameraRollExample.js
+++ b/example/js/CameraRollExample.js
@@ -25,7 +25,7 @@ const {
 import CameraRoll from '../../js/CameraRoll';
 import type {PhotoIdentifier, GroupTypes} from '../../js/CameraRoll';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('invariant');
 
 const CameraRollView = require('./CameraRollView');
 

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -11,7 +11,7 @@
 import {Platform} from 'react-native';
 import RNCCameraRoll from './nativeInterface';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('invariant');
 
 const GROUP_TYPES_OPTIONS = {
   Album: 'Album',

--- a/package.json
+++ b/package.json
@@ -126,5 +126,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-cameraroll.git"
+  },
+  "dependencies": {
+    "invariant": "^2.2.4"
   }
 }


### PR DESCRIPTION
- Remove fbjs dependency, which was throwing an error since we don't have that after upgrading reanimated

More info here https://github.com/react-native-cameraroll/react-native-cameraroll/pull/367